### PR TITLE
fix(encoders): add error handling to en/decodeURI

### DIFF
--- a/plugins/toolbox/src/components/Encoders/UrlEncode.tsx
+++ b/plugins/toolbox/src/components/Encoders/UrlEncode.tsx
@@ -7,11 +7,16 @@ export const UrlEncode = () => {
   const [mode, setMode] = React.useState('Encode');
 
   useEffect(() => {
-    if (mode === 'Encode') {
-      setOutput(encodeURI(input));
-    } else {
-      setOutput(decodeURI(input));
+    let url = '';
+    let errorMessage = '';
+    try {
+      url = mode === 'Encode' ? encodeURI(input) : decodeURI(input);
+    } catch (error) {
+      errorMessage = `couldn't ${
+        mode === 'Encode' ? 'encode' : 'decode'
+      } URL...`;
     }
+    setOutput(url || errorMessage);
   }, [input, mode]);
 
   return (


### PR DESCRIPTION
Hello,

**Tool:** Encode/Decode - URL
**Fixes**: #30 

Please find PR for your consideration. 

This pull request adds error handling in the useEffect hook that is responsible for encoding and decoding URLs. The current implementation of the useEffect hook does not handle errors that may occur during the encoding or decoding process, leading to a URIError: URI malformed error when inputs are provided that the encodeURI or decodeURI was unable to proess properly.

To fix this issue, I have added a try-catch block to the useEffect hook to handle errors that may occur during the encoding or decoding process, If an error occurs, a message is displayed in the output. 

<img width="1323" alt="image" src="https://user-images.githubusercontent.com/25988124/227594228-dee986e4-ad10-48b6-af32-7732c5e8b6d3.png">


Thanks

