### PR TITLE
fix: date constructor expects milliseconds

### DIFF
--- a/plugins/toolbox/src/components/Encoders/JwtDecoder.tsx
+++ b/plugins/toolbox/src/components/Encoders/JwtDecoder.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import jwtDecode from 'jwt-decode';
+import jwtDecode, { JwtPayload } from 'jwt-decode';
 import { DefaultEditor } from '../DefaultEditor';
 
 export const JwtDecoder = () => {
@@ -12,12 +12,12 @@ export const JwtDecoder = () => {
   useEffect(() => {
     if (input) {
       try {
-        const jwtPayload = jwtDecode(input) as { iat?: number; exp?: number };
+        const jwtPayload = jwtDecode<JwtPayload>(input);
         setOutput(`Issued date:
-${jwtPayload.iat && new Date(jwtPayload.iat)}
+${jwtPayload.iat && new Date(jwtPayload.iat * 1000)}
 
 Expiration date:
-${jwtPayload.exp && new Date(jwtPayload.exp)}
+${jwtPayload.exp && new Date(jwtPayload.exp * 1000)}
 
 Header:
 ${JSON.stringify(jwtDecode(input, { header: true }), null, 2)}


### PR DESCRIPTION

Fixes #34 

The value of jwtPayload.iat seems to be in seconds, whereas Date constructor expects the value to be in milliseconds. 

<img width="1287" alt="image" src="https://user-images.githubusercontent.com/25988124/228304891-7ed7c217-1d2e-4c10-9a69-d18c1ed274f1.png">