### PR TITLE
feat: add diff tool

### DIFF
--- a/plugins/toolbox/package.json
+++ b/plugins/toolbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drodil/backstage-plugin-toolbox",
-  "version": "1.10.0",
+  "version": "1.9.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "prepublishOnly": "yarn tsc && yarn build",

--- a/plugins/toolbox/package.json
+++ b/plugins/toolbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drodil/backstage-plugin-toolbox",
-  "version": "1.9.2",
+  "version": "1.10.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "prepublishOnly": "yarn tsc && yarn build",
@@ -37,6 +37,8 @@
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.57",
+    "@monaco-editor/react": "^4.5.1",
+    "monaco-editor": "^0.38.0",
     "@roadiehq/roadie-backstage-entity-validator": "^2.1.2",
     "color-convert": "^2.0.1",
     "crypto-hash": "^2.0.1",

--- a/plugins/toolbox/src/components/Buttons/FileUploadButton.tsx
+++ b/plugins/toolbox/src/components/Buttons/FileUploadButton.tsx
@@ -1,0 +1,41 @@
+import {Button, Tooltip} from "@material-ui/core";
+import AttachFile from "@material-ui/icons/AttachFile";
+import React from "react";
+
+type Props = {
+    onFileLoad: (input: File) => void;
+    id: string;
+    buttonText?: string;
+};
+
+export const FileUploadButton = (props: Props) => {
+    const { onFileLoad, id, buttonText = "Upload File" } = props;
+
+    return (
+        <>
+            <Tooltip arrow title="Upload File">
+                <label htmlFor={id}>
+                    <Button
+                        component="span"
+                        size="small"
+                        startIcon={<AttachFile />}
+                    >
+                        {buttonText}
+                    </Button>
+                </label>
+            </Tooltip>
+            <input
+                type="file"
+                accept="*/*"
+                id={id}
+                hidden
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                    if (!e?.target?.files?.length) {
+                        return null;
+                    }
+                    return onFileLoad(e.target.files[0]);
+                }}
+            />
+        </>
+    );
+};

--- a/plugins/toolbox/src/components/Buttons/index.ts
+++ b/plugins/toolbox/src/components/Buttons/index.ts
@@ -3,3 +3,4 @@ export { CopyToClipboardButton } from './CopyToClipboardButton';
 export { FavoriteButton } from './FavoriteButton';
 export { PasteFromClipboardButton } from './PasteFromClipboardButton';
 export { SampleButton } from './SampleButton';
+export { FileUploadButton } from './FileUploadButton';

--- a/plugins/toolbox/src/components/Misc/Diff.tsx
+++ b/plugins/toolbox/src/components/Misc/Diff.tsx
@@ -1,0 +1,171 @@
+import { DiffEditor } from '@monaco-editor/react';
+import React, { useEffect, useState } from 'react';
+import { Button, FormControl, Grid } from '@material-ui/core';
+import { useStyles } from '../../utils/hooks';
+import * as monaco from 'monaco-editor';
+import { useEffectOnce } from 'react-use';
+import { Select, SelectItem } from '@backstage/core-components';
+
+const options: monaco.editor.IDiffEditorConstructionOptions = {
+    originalEditable: true,
+    diffCodeLens: true,
+    dragAndDrop: true,
+    tabCompletion: 'on',
+    renderSideBySide: true,
+};
+
+const FileUploader = ({
+                          onFileLoad,
+                          id,
+                          buttonText,
+                      }: {
+    onFileLoad: Function;
+    id: string;
+    buttonText: string;
+}) => {
+    return (
+        <>
+            <input
+                type="file"
+                accept="*/*"
+                id={id}
+                hidden
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                    if (e?.target?.files && e.target.files.length) {
+                        return onFileLoad(e.target.files[0]);
+                    }
+                    return null;
+                }}
+            />
+            <label htmlFor={id}>
+                <Button variant="contained" color="primary" component="span">
+                    {buttonText}
+                </Button>
+            </label>
+        </>
+    );
+};
+
+function readFileAndSetText(
+    file: File | undefined,
+    setText: (value: ((prevState: string) => string) | string) => void,
+    setLanguage: (value: ((prevState: string) => string) | string) => void,
+    allowedLanguages: MonacoLanguages[],
+) {
+    if (file) {
+        const reader = new FileReader();
+        reader.onload = async e => {
+            // @ts-ignore
+            setText(e.target.result);
+        };
+        reader.readAsText(file);
+        let newLanguage = 'plaintext';
+        const extension = `.${file.name.split('.').pop()}`;
+        if (allowedLanguages?.length) {
+            for (let i = 0; i < allowedLanguages.length; i++) {
+                if (allowedLanguages[i].extensions.includes(extension as string)) {
+                    newLanguage = allowedLanguages[i].name;
+                    break;
+                }
+            }
+        }
+        setLanguage(newLanguage);
+    }
+}
+
+export type MonacoLanguages = { name: string; extensions: string[] };
+
+function Diff() {
+    const styles = useStyles();
+    const [originalFile, setOriginalFile] = useState<File>();
+    const [modifiedFile, setModifiedFile] = useState<File>();
+
+    const [originalText, setOriginalText] = useState(
+        `Backstage toolbox\n\ncompare text`,
+    );
+    const [modifiedText, setModifiedText] = useState(
+        `Backstage toolbox\ndiff editor`,
+    );
+    const [language, setLanguage] = useState('plaintext');
+
+    const [allowedLanguages, setAllowedLanguages] = useState<MonacoLanguages[]>(
+        [],
+    );
+
+    const handleLanguageSelect = (selected: any) => {
+        setLanguage(selected);
+    };
+
+    useEffect(() => {
+        readFileAndSetText(
+            modifiedFile,
+            setModifiedText,
+            setLanguage,
+            allowedLanguages,
+        );
+    }, [modifiedFile, allowedLanguages]);
+
+    useEffect(() => {
+        readFileAndSetText(
+            originalFile,
+            setOriginalText,
+            setLanguage,
+            allowedLanguages,
+        );
+    }, [originalFile, allowedLanguages]);
+
+    useEffectOnce(() => {
+        const languages: MonacoLanguages[] = monaco.languages
+            .getLanguages()
+            .map(each => {
+                return { name: each.id, extensions: each.extensions || [] };
+            });
+        setAllowedLanguages(languages);
+    });
+
+    const languageOptions: SelectItem[] = allowedLanguages
+        ? allowedLanguages.map(i => ({ label: i.name, value: i.name }))
+        : [{ label: 'Loading...', value: 'loading' }];
+
+    return (
+        <>
+            <FormControl className={styles.fullWidth}>
+                <Grid container style={{ width: '100%' }}>
+                    <Grid item style={{ minWidth: '200px' }}>
+                        <Select
+                            selected={language}
+                            onChange={handleLanguageSelect}
+                            items={languageOptions}
+                            label="Select File Language Type"
+                        />
+                    </Grid>
+                </Grid>
+                <Grid container style={{ marginBottom: '5px', width: '100%' }}>
+                    <Grid item style={{ width: '50%' }}>
+                        <FileUploader
+                            onFileLoad={setOriginalFile}
+                            id="originalFile"
+                            buttonText="Upload Original File"
+                        />
+                    </Grid>
+                    <Grid item style={{ width: '50%' }}>
+                        <FileUploader
+                            onFileLoad={setModifiedFile}
+                            id="modifiedFile"
+                            buttonText="Upload Modified File"
+                        />
+                    </Grid>
+                </Grid>
+                <DiffEditor
+                    height="100vh"
+                    original={originalText}
+                    modified={modifiedText}
+                    options={options}
+                    language={language}
+                />
+            </FormControl>
+        </>
+    );
+}
+
+export default Diff;

--- a/plugins/toolbox/src/components/Misc/Diff.tsx
+++ b/plugins/toolbox/src/components/Misc/Diff.tsx
@@ -29,6 +29,11 @@ const options: monaco.editor.IDiffEditorConstructionOptions = {
     renderSideBySide: true,
 };
 
+function getLanguage(allowedLanguages: MonacoLanguages[], extension: string) {
+    return allowedLanguages.find(monacoLanguage =>
+        monacoLanguage.extensions.includes(extension as string))?.name;
+}
+
 function readFileAndSetText(
     file: File | undefined,
     setText: (value: ((prevState: string) => string) | string) => void,
@@ -48,12 +53,7 @@ function readFileAndSetText(
     let newLanguage = 'plaintext';
     const extension = `.${file.name.split('.').pop()}`;
     if (allowedLanguages?.length) {
-        for (let i = 0; i < allowedLanguages.length; i++) {
-            if (allowedLanguages[i].extensions.includes(extension as string)) {
-                newLanguage = allowedLanguages[i].name;
-                break;
-            }
-        }
+        newLanguage = getLanguage(allowedLanguages, extension) || newLanguage;
     }
     setLanguage(newLanguage);
 }

--- a/plugins/toolbox/src/components/Root/tools.tsx
+++ b/plugins/toolbox/src/components/Root/tools.tsx
@@ -25,6 +25,7 @@ const EntityValidator = lazy(() => import('../Validators/EntityValidator'));
 const EntityDescriber = lazy(() => import('../Misc/EntityDescriber'));
 const Countdown = lazy(() => import('../Misc/Countdown'));
 const Timer = lazy(() => import('../Misc/Timer'));
+const Diff = lazy(() => import('../Misc/Diff'));
 
 const LoremIpsum = lazy(() => import('../Generators/LoremIpsum'));
 const Hash = lazy(() => import('../Generators/Hash'));
@@ -202,6 +203,12 @@ export const defaultTools: Tool[] = [
     id: 'stopwatch',
     name: 'Stopwatch timer',
     component: <Timer />,
+    category: 'Miscellaneous',
+  },
+  {
+    id: 'diff',
+    name: 'File Diff',
+    component: <Diff />,
     category: 'Miscellaneous',
   },
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2462,6 +2462,20 @@
     prop-types "^15.7.2"
     react-is "^16.8.0 || ^17.0.0"
 
+"@monaco-editor/loader@^1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@monaco-editor/loader/-/loader-1.3.3.tgz#7f1742bd3cc21c0362a46a4056317f6e5215cfca"
+  integrity sha512-6KKF4CTzcJiS8BJwtxtfyYt9shBiEv32ateQ9T4UVogwn4HM/uPo9iJd2Dmbkpz8CM6Y0PDUpjnZzCwC+eYo2Q==
+  dependencies:
+    state-local "^1.0.6"
+
+"@monaco-editor/react@^4.5.1":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@monaco-editor/react/-/react-4.5.1.tgz#fbc76c692aee9a33b9ab24ae0c5f219b8f002fdb"
+  integrity sha512-NNDFdP+2HojtNhCkRfE6/D6ro6pBNihaOzMbGK84lNWzRu+CfBjwzGt4jmnqimLuqp5yE5viHS2vi+QOAnD5FQ==
+  dependencies:
+    "@monaco-editor/loader" "^1.3.3"
+
 "@mswjs/cookies@^0.2.2":
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@mswjs/cookies/-/cookies-0.2.2.tgz#b4e207bf6989e5d5427539c2443380a33ebb922b"
@@ -3526,9 +3540,9 @@
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
 "@types/react-dom@<18.0.0", "@types/react-dom@^17":
-  version "17.0.19"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.19.tgz#36feef3aa35d045cacd5ed60fe0eef5272f19492"
-  integrity sha512-PiYG40pnQRdPHnlf7tZnp0aQ6q9tspYr72vD61saO6zFCybLfMqwUCN0va1/P+86DXn18ZWeW30Bk7xlC5eEAQ==
+  version "17.0.20"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.20.tgz#e0c8901469d732b36d8473b40b679ad899da1b53"
+  integrity sha512-4pzIjSxDueZZ90F52mU3aPoogkHIoSIDG+oQ+wQK7Cy2B9S+MvOqY0uEA/qawKz381qrEDkvpwyt8Bm31I8sbA==
   dependencies:
     "@types/react" "^17"
 
@@ -9922,6 +9936,11 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
+monaco-editor@^0.38.0:
+  version "0.38.0"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.38.0.tgz#7b3cd16f89b1b8867fcd3c96e67fccee791ff05c"
+  integrity sha512-11Fkh6yzEmwx7O0YoLxeae0qEGFwmyPRlVxpg7oF9czOOCB/iCjdJrG5I67da5WiXK3YJCxoz9TJFE8Tfq/v9A==
+
 moo@^0.5.0:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.2.tgz#f9fe82473bc7c184b0d32e2215d3f6e67278733c"
@@ -12439,6 +12458,11 @@ standard-version@^9.5.0:
     semver "^7.1.1"
     stringify-package "^1.0.1"
     yargs "^16.0.0"
+
+state-local@^1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/state-local/-/state-local-1.0.7.tgz#da50211d07f05748d53009bee46307a37db386d5"
+  integrity sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==
 
 statuses@2.0.1:
   version "2.0.1"


### PR DESCRIPTION
Adds a diff tool based on [monaco-editor](https://github.com/microsoft/monaco-editor).

- Allows for text copy, paste, text selection dragging, and optionally upload a local file.
- Manual text language selection provided for code [Intellisense](https://code.visualstudio.com/docs/editor/intellisense)
- Automatic language selection based on uploaded file extensions


![toolbox_screenshot](https://github.com/drodil/backstage-plugin-toolbox/assets/23493031/cad1dea1-f482-407e-9a12-b2be6775fc87)
