### PR TITLE
fix: imported crypto-hash modules from browser

### DIFF
--- a/plugins/toolbox/src/components/Generators/Hash.tsx
+++ b/plugins/toolbox/src/components/Generators/Hash.tsx
@@ -4,7 +4,7 @@ import { TextField } from '@material-ui/core';
 import { useStyles } from '../../utils/hooks';
 import { faker } from '@faker-js/faker';
 import { CopyToClipboardButton } from '../Buttons/CopyToClipboardButton';
-import { sha1, sha256, sha384, sha512 } from 'crypto-hash';
+import { sha1, sha256, sha384, sha512 } from 'crypto-hash/browser';
 import { Md5 } from 'ts-md5';
 // @ts-ignore
 import md2 from 'js-md2';


### PR DESCRIPTION
while trying to import the this extension I encountered an error that was happening due to this file importing the crypto-hash methods from the nodejs api rather than the browser one. This PR is a request to have the same methods be imported from the browser version instead. 