### PR TITLE
fix: removed autofocus prop from widgets using textarea

### DIFF
--- a/plugins/toolbox/src/components/DefaultEditor/DefaultEditor.tsx
+++ b/plugins/toolbox/src/components/DefaultEditor/DefaultEditor.tsx
@@ -182,7 +182,6 @@ export const DefaultEditor = (props: Props) => {
               <TextField
                 label={inputLabel}
                 // eslint-disable-next-line
-                autoFocus
                 id="input"
                 multiline
                 className={classes.fullWidth}


### PR DESCRIPTION
This is a solution for an issue I opened. https://github.com/drodil/backstage-plugin-toolbox/issues/116

This will fix the accessibility issue that the plugin has when a user has a toolbox widget on the custom homepage that goes off screen. 

By removing the autofocus prop from the <TextField /> component, this will no longer cause any widgets using the textarea input to autofocus the user to the bottom of the screen.

https://github.com/drodil/backstage-plugin-toolbox/assets/53197034/c3fda910-e3aa-4bfb-a44b-ebca3d319ccc
This is replication of the error

https://github.com/drodil/backstage-plugin-toolbox/assets/53197034/c146a4fe-6784-4835-99e2-547cfde88d54
This is the fix
