### PR TITLE
feat: allow customization and download of qr code

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -2,6 +2,17 @@ app:
   title: Toolbox Dev App
   baseUrl: http://localhost:3000
 
+  toolbox:
+    qrCode:
+      defaults:
+        dotType: rounded
+        dotColor: 'blue'
+        cornerSquareType: extra-rounded
+        cornerSquareColor: 'blue'
+        cornerDotType: dot
+        cornerDotColor: 'blue'
+        shape: square
+
 backend:
   baseUrl: http://localhost:7007
   listen:

--- a/plugins/toolbox/config.d.ts
+++ b/plugins/toolbox/config.d.ts
@@ -1,4 +1,4 @@
-import {CornerDotType, CornerSquareType, DotType, ShapeType} from "qr-code-styling";
+import type {CornerDotType, CornerSquareType, DotType, ShapeType} from "qr-code-styling";
 
 export interface Config {
     app: {

--- a/plugins/toolbox/config.d.ts
+++ b/plugins/toolbox/config.d.ts
@@ -1,55 +1,60 @@
-import type {CornerDotType, CornerSquareType, DotType, ShapeType} from "qr-code-styling";
+import type {
+  CornerDotType,
+  CornerSquareType,
+  DotType,
+  ShapeType,
+} from 'qr-code-styling';
 
 export interface Config {
-    app: {
-        toolbox: {
-            /**
-             * QR code settings
-             * @visibility frontend
-             */
-            qrCode: {
-                /**
-                 * all the defaults for the qr code generator
-                 * @deepVisibility frontend
-                 */
-                defaults: {
-                    /**
-                     * Dot type
-                     * @visibility frontend
-                     */
-                    dotType: DotType;
-                    /**
-                     * Dot color
-                     * @visibility frontend
-                     */
-                    dotColor: string;
-                    /**
-                     * Corner square type
-                     * @visibility frontend
-                     */
-                    cornerSquareType: CornerSquareType;
-                    /**
-                     * Corner square color
-                     * @visibility frontend
-                     */
-                    cornerSquareColor: string;
-                    /**
-                     * Corner dot type
-                     * @visibility frontend
-                     */
-                    cornerDotType: CornerDotType;
-                    /**
-                     * Corner dot color
-                     * @visibility frontend
-                     */
-                    cornerDotColor: string;
-                    /**
-                     * Shape
-                     * @visibility frontend
-                     */
-                    shape: ShapeType;
-                };
-            };
+  app: {
+    toolbox: {
+      /**
+       * QR code settings
+       * @visibility frontend
+       */
+      qrCode: {
+        /**
+         * all the defaults for the qr code generator
+         * @deepVisibility frontend
+         */
+        defaults: {
+          /**
+           * Dot type
+           * @visibility frontend
+           */
+          dotType: DotType;
+          /**
+           * Dot color
+           * @visibility frontend
+           */
+          dotColor: string;
+          /**
+           * Corner square type
+           * @visibility frontend
+           */
+          cornerSquareType: CornerSquareType;
+          /**
+           * Corner square color
+           * @visibility frontend
+           */
+          cornerSquareColor: string;
+          /**
+           * Corner dot type
+           * @visibility frontend
+           */
+          cornerDotType: CornerDotType;
+          /**
+           * Corner dot color
+           * @visibility frontend
+           */
+          cornerDotColor: string;
+          /**
+           * Shape
+           * @visibility frontend
+           */
+          shape: ShapeType;
         };
+      };
     };
+  };
 }

--- a/plugins/toolbox/config.d.ts
+++ b/plugins/toolbox/config.d.ts
@@ -1,58 +1,51 @@
-import type {
-  CornerDotType,
-  CornerSquareType,
-  DotType,
-  ShapeType,
-} from 'qr-code-styling';
-
 export interface Config {
   app: {
-    toolbox: {
+    toolbox?: {
       /**
        * QR code settings
        * @visibility frontend
        */
-      qrCode: {
+      qrCode?: {
         /**
          * all the defaults for the qr code generator
          * @deepVisibility frontend
          */
-        defaults: {
+        defaults?: {
           /**
            * Dot type
            * @visibility frontend
            */
-          dotType: DotType;
+          dotType?: string;
           /**
            * Dot color
            * @visibility frontend
            */
-          dotColor: string;
+          dotColor?: string;
           /**
            * Corner square type
            * @visibility frontend
            */
-          cornerSquareType: CornerSquareType;
+          cornerSquareType?: string;
           /**
            * Corner square color
            * @visibility frontend
            */
-          cornerSquareColor: string;
+          cornerSquareColor?: string;
           /**
            * Corner dot type
            * @visibility frontend
            */
-          cornerDotType: CornerDotType;
+          cornerDotType?: string;
           /**
            * Corner dot color
            * @visibility frontend
            */
-          cornerDotColor: string;
+          cornerDotColor?: string;
           /**
            * Shape
            * @visibility frontend
            */
-          shape: ShapeType;
+          shape?: string;
         };
       };
     };

--- a/plugins/toolbox/config.d.ts
+++ b/plugins/toolbox/config.d.ts
@@ -1,0 +1,55 @@
+import {CornerDotType, CornerSquareType, DotType, ShapeType} from "qr-code-styling";
+
+export interface Config {
+    app: {
+        toolbox: {
+            /**
+             * QR code settings
+             * @visibility frontend
+             */
+            qrCode: {
+                /**
+                 * all the defaults for the qr code generator
+                 * @deepVisibility frontend
+                 */
+                defaults: {
+                    /**
+                     * Dot type
+                     * @visibility frontend
+                     */
+                    dotType: DotType;
+                    /**
+                     * Dot color
+                     * @visibility frontend
+                     */
+                    dotColor: string;
+                    /**
+                     * Corner square type
+                     * @visibility frontend
+                     */
+                    cornerSquareType: CornerSquareType;
+                    /**
+                     * Corner square color
+                     * @visibility frontend
+                     */
+                    cornerSquareColor: string;
+                    /**
+                     * Corner dot type
+                     * @visibility frontend
+                     */
+                    cornerDotType: CornerDotType;
+                    /**
+                     * Corner dot color
+                     * @visibility frontend
+                     */
+                    cornerDotColor: string;
+                    /**
+                     * Shape
+                     * @visibility frontend
+                     */
+                    shape: ShapeType;
+                };
+            };
+        };
+    };
+}

--- a/plugins/toolbox/package.json
+++ b/plugins/toolbox/package.json
@@ -66,6 +66,7 @@
     "lodash": "^4.17.21",
     "luxon": "^3.4.3",
     "monaco-editor": "^0.44.0",
+    "qr-code-styling": "^1.6.2",
     "quicktype-core": "^23.0.168",
     "react-barcode": "^1.4.6",
     "react-qr-code": "^2.0.12",
@@ -105,6 +106,8 @@
     "cross-fetch": "^3.1.5"
   },
   "files": [
-    "dist"
-  ]
+    "dist",
+    "config.d.ts"
+  ],
+  "configSchema": "config.d.ts"
 }

--- a/plugins/toolbox/src/components/Generators/QRCode.tsx
+++ b/plugins/toolbox/src/components/Generators/QRCode.tsx
@@ -1,21 +1,230 @@
-import React from 'react';
-import { DefaultEditor } from '../DefaultEditor';
-import { faker } from '@faker-js/faker';
-import QRCode from 'react-qr-code';
+import React, {ChangeEvent, useCallback, useMemo} from 'react';
+import {DefaultEditor} from '../DefaultEditor';
+import {faker} from '@faker-js/faker';
+import QRCodeStyling, {CornerDotType, CornerSquareType, DotType, FileExtension, ShapeType} from "qr-code-styling";
+import {Box, Button, Select, SelectChangeEvent} from '@mui/material';
+import MenuItem from "@mui/material/MenuItem";
+import InputLabel from "@mui/material/InputLabel";
+import FormControl from "@mui/material/FormControl";
+import TextField from "@mui/material/TextField";
+import {configApiRef, useApi} from "@backstage/core-plugin-api";
+
+interface QrCodeSettings {
+    cornerSquareType: CornerSquareType;
+    cornerSquareColor: string;
+    cornerDotType: CornerDotType;
+    cornerDotColor: string;
+    dotType: DotType;
+    dotColor: string;
+    shape: ShapeType;
+}
 
 export const QRCodeGenerator = () => {
-  const [input, setInput] = React.useState('');
-  const sample = faker.internet.url();
+    const [input, setInput] = React.useState('');
+    const sample = faker.internet.url();
 
-  return (
-    <DefaultEditor
-      input={input}
-      setInput={setInput}
-      inputProps={{ maxLength: 2048 }}
-      sample={sample}
-      rightContent={<QRCode size={512} value={input.substring(0, 2048)} />}
-    />
-  );
+    const [fileExt, setFileExt] = React.useState<FileExtension>("png");
+    const ref = React.useRef(null);
+
+    const config = useApi(configApiRef).getOptionalConfig('app.toolbox.qrCode');
+
+    let defaultColor = '#000';
+    const defaults: QrCodeSettings = {
+        cornerSquareType: config?.getOptionalString('defaults.cornerSquareType') as CornerSquareType ?? 'square',
+        cornerSquareColor: config?.getOptionalString('defaults.cornerSquareColor') ?? defaultColor,
+        cornerDotType: config?.getOptionalString('defaults.cornerDotType') as CornerDotType ?? "square",
+        cornerDotColor: config?.getOptionalString('defaults.cornerDotColor') ?? defaultColor,
+        dotType: config?.getOptionalString('defaults.dotType') as DotType ?? 'square',
+        dotColor: config?.getOptionalString('defaults.dotColor') ?? defaultColor,
+        shape: config?.getOptionalString('defaults.shape') as ShapeType ?? 'square',
+    };
+
+    // settings
+    const [settings, setSettings] = React.useState<QrCodeSettings>(defaults);
+
+    const qrCode = useMemo(() => {
+        const qr = new QRCodeStyling({
+            width: 500,
+            height: 500,
+            image: "",
+            dotsOptions: {
+                color: settings.dotColor,
+                type: settings.dotType,
+            },
+            cornersSquareOptions: {
+                color: settings.cornerSquareColor,
+                type: settings.cornerSquareType,
+            },
+            cornersDotOptions: {
+                color: settings.cornerDotColor,
+                type: settings.cornerDotType,
+            },
+            shape: settings.shape,
+            imageOptions: {
+                crossOrigin: "anonymous",
+                margin: 20
+            },
+            margin: 5,
+        });
+
+        if (ref.current) {
+            qr.append(ref.current);
+            console.log("Connected")
+        }
+        return qr;
+    }, [ref.current]);
+
+
+    React.useEffect(() => {
+        qrCode.update({
+            data: input,
+            dotsOptions: {
+                color: settings.dotColor,
+                type: settings.dotType,
+            },
+            cornersSquareOptions: {
+                color: settings.cornerSquareColor,
+                type: settings.cornerSquareType,
+            },
+            cornersDotOptions: {
+                color: settings.cornerDotColor,
+                type: settings.cornerDotType,
+            },
+            shape: settings.shape,
+        });
+        console.log(input)
+    }, [input, settings]);
+
+    const onExtensionChange = (event: SelectChangeEvent) => {
+        setFileExt(event.target.value as FileExtension);
+    };
+
+    const onDownloadClick = () => {
+        void qrCode.download({
+            extension: fileExt
+        });
+    };
+
+
+    let DownloadOptions = <span>{'File type: '}
+        <Select onChange={onExtensionChange}
+                label={'file extension'}
+                variant={'standard'}
+                placeholder={'file extension'}
+                defaultValue={'png'}
+                key={'selectExtensionChanger'}>
+        <MenuItem key={'png'} value={'png'}>png</MenuItem>
+        <MenuItem key={'webp'} value={'webp'}>webp</MenuItem>
+        <MenuItem key={'jpeg'} value={'jpeg'}>jpeg</MenuItem>
+        <MenuItem key={'svg'} value={'svg'}>svg</MenuItem>
+    </Select>
+        <Button onClick={onDownloadClick} key={'downloadbutton'}>Download</Button>
+    </span>;
+
+    return (
+        <>
+            <Box
+                sx={{margin: 5}}>
+            </Box>
+
+            <DefaultEditor
+                input={input}
+                setInput={(value) => {
+                    setInput(value);
+                }}
+                inputProps={{maxLength: 2048}}
+                sample={sample}
+                rightContent={<div ref={ref}/>}
+                extraRightContent={DownloadOptions}
+                additionalTools={[
+                    <ConfigSelect settingKey={"dotType" as const}
+                                  name={"Dot"}
+                                  key={'dotSelect'}
+                                  types={["square", 'classy', "dots", "classy-rounded", "extra-rounded", 'rounded'] as DotType[]}
+                                  settings={settings}
+                                  setSettings={setSettings}
+                    />,
+                    <ConfigSelect settingKey={"cornerSquareType" as const}
+                                  name={"Corner Square"}
+                                  key={'cornerSquareSelect'}
+                                  types={['square', 'dot', 'extra-rounded'] as CornerSquareType[]}
+                                  settings={settings}
+                                  setSettings={setSettings}
+                    />,
+                    <ConfigSelect settingKey={"cornerDotType" as const}
+                                  name={"Corner Dot"}
+                                  key={'cornerDotSelect'}
+                                  types={['dot', 'square'] as CornerDotType[]}
+                                  settings={settings}
+                                  setSettings={setSettings}
+                    />,
+                    <ConfigSelect settingKey={"shape" as const}
+                                  name={"Shape"}
+                                  key={'shapeSelect'}
+                                  types={['circle', 'square'] as ShapeType[]}
+                                  settings={settings}
+                                  setSettings={setSettings}
+                    />,
+                ]}
+            />
+        </>
+    );
+};
+
+
+let ConfigSelect = (props: {
+    settingKey: keyof QrCodeSettings,
+    name: string,
+    types: DotType[] | CornerDotType[] | CornerSquareType[] | ShapeType[]
+    settings : QrCodeSettings,
+    setSettings : (settings: QrCodeSettings) => void,
+}) => {
+    const onChange = useCallback((event: SelectChangeEvent) => props.setSettings({
+        ...props.settings,
+        [props.settingKey]: event.target.value as DotType
+    }), [props.settings]);
+
+    const labelId = `label-for-${props.settingKey}`
+    let between = '3px';
+    let colorSetting = props.settingKey.replace('Type', 'Color') as keyof QrCodeSettings;
+    const onChangeColor = useCallback((event: ChangeEvent<HTMLInputElement>) => props.setSettings({
+        ...props.settings,
+        [colorSetting]: event.target.value as DotType
+    }), [props.settings]);
+
+    return (<FormControl key={`formcontrol-for-select-${props.settingKey}`}>
+            <InputLabel id={labelId}>{props.name}</InputLabel>
+            <Select
+                key={`select-for-${props.settingKey}`}
+                name={'select'}
+                variant="outlined"
+                labelId={labelId}
+                label={props.name}
+                id={`id-${props.settingKey}`}
+                onChange={onChange}
+                value={props.settings[props.settingKey]}
+                sx={{width: 140, margin: `0 ${between}`}}
+            >
+                {
+                    props.types ? props.types.map((value) =>
+                        <MenuItem value={value} key={`selectFor${props.name}menu${value}`}>
+                            {value}
+                        </MenuItem>
+                    ) : null
+                }
+            </Select>
+            {props.name !== 'Shape' ? <TextField
+                id="input"
+                name="input"
+                label={`${props.name} color`}
+                defaultValue={props.settings[colorSetting]}
+                onChange={onChangeColor}
+                variant="outlined"
+                sx={{width: 140, margin: `10px ${between} 0 ${between}`}}
+            /> : null}
+        </FormControl>
+    );
 };
 
 export default QRCodeGenerator;
+

--- a/plugins/toolbox/src/components/Generators/QRCode.tsx
+++ b/plugins/toolbox/src/components/Generators/QRCode.tsx
@@ -1,8 +1,14 @@
 import type { ChangeEvent } from 'react';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 
-import {faker} from '@faker-js/faker';
-import type { CornerDotType, CornerSquareType, DotType, FileExtension, ShapeType } from 'qr-code-styling';
+import { faker } from '@faker-js/faker';
+import type {
+  CornerDotType,
+  CornerSquareType,
+  DotType,
+  FileExtension,
+  ShapeType,
+} from 'qr-code-styling';
 import QRCodeStyling from 'qr-code-styling';
 import MenuItem from '@mui/material/MenuItem';
 import InputLabel from '@mui/material/InputLabel';
@@ -12,44 +18,57 @@ import { DefaultEditor } from '@drodil/backstage-plugin-toolbox';
 
 import { configApiRef, useApi } from '@backstage/core-plugin-api';
 import Select, { SelectChangeEvent } from '@mui/material/Select';
-import Button from "@mui/material/Button";
-import Box from "@mui/material/Box";
+import Button from '@mui/material/Button';
+import Box from '@mui/material/Box';
 
 interface QrCodeSettings {
-    cornerSquareType: CornerSquareType;
-    cornerSquareColor: string;
-    cornerDotType: CornerDotType;
-    cornerDotColor: string;
-    dotType: DotType;
-    dotColor: string;
-    shape: ShapeType;
+  cornerSquareType: CornerSquareType;
+  cornerSquareColor: string;
+  cornerDotType: CornerDotType;
+  cornerDotColor: string;
+  dotType: DotType;
+  dotColor: string;
+  shape: ShapeType;
 }
 
 const ConfigSelect = (props: {
   readonly settingKey: keyof QrCodeSettings;
   readonly name: string;
-  readonly types: DotType[] | CornerDotType[] | CornerSquareType[] | ShapeType[];
+  readonly types:
+    | DotType[]
+    | CornerDotType[]
+    | CornerSquareType[]
+    | ShapeType[];
   readonly settings: QrCodeSettings;
   readonly setSettings: (settings: QrCodeSettings) => void;
 }) => {
-  const onChange = useCallback((event: SelectChangeEvent) => props.setSettings({
-    ...props.settings,
-    [props.settingKey]: event.target.value as DotType,
-  }), [props]);
+  const onChange = useCallback(
+    (event: SelectChangeEvent) =>
+      props.setSettings({
+        ...props.settings,
+        [props.settingKey]: event.target.value as DotType,
+      }),
+    [props],
+  );
 
   const labelId = `label-for-${props.settingKey}`;
   const between = '3px';
-  const colorSetting = props.settingKey.replace('Type', 'Color') as keyof QrCodeSettings;
-  const onChangeColor = useCallback((event: ChangeEvent<HTMLInputElement>) => props.setSettings({
-    ...props.settings,
-    [colorSetting]: event.target.value as DotType,
-  }), [colorSetting, props]);
+  const colorSetting = props.settingKey.replace(
+    'Type',
+    'Color',
+  ) as keyof QrCodeSettings;
+  const onChangeColor = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) =>
+      props.setSettings({
+        ...props.settings,
+        [colorSetting]: event.target.value as DotType,
+      }),
+    [colorSetting, props],
+  );
 
   return (
     <FormControl key={`formcontrol-for-select-${props.settingKey}`}>
-      <InputLabel id={labelId}>
-        {props.name}
-      </InputLabel>
+      <InputLabel id={labelId}>{props.name}</InputLabel>
       <Select
         id={`id-${props.settingKey}`}
         key={`select-for-${props.settingKey}`}
@@ -61,116 +80,133 @@ const ConfigSelect = (props: {
         value={props.settings[props.settingKey]}
         variant="outlined"
       >
-        {
-          props.types
-            ? props.types.map((value) =>
-              (
-                <MenuItem
-                  key={`selectFor${props.name}menu${value}`}
-                  value={value}
-                >
-                  {value}
-                </MenuItem>))
-            : null
-        }
+        {props.types
+          ? props.types.map(value => (
+              <MenuItem
+                key={`selectFor${props.name}menu${value}`}
+                value={value}
+              >
+                {value}
+              </MenuItem>
+            ))
+          : null}
       </Select>
-      {props.name !== 'Shape'
-        ? (
-          <TextField
-            defaultValue={props.settings[colorSetting]}
-            id="input"
-            label={`${props.name} color`}
-            name="input"
-            onChange={onChangeColor}
-            sx={{ width: 140, margin: `10px ${between} 0 ${between}` }}
-            variant="outlined"
-          />)
-        : null}
+      {props.name !== 'Shape' ? (
+        <TextField
+          defaultValue={props.settings[colorSetting]}
+          id="input"
+          label={`${props.name} color`}
+          name="input"
+          onChange={onChangeColor}
+          sx={{ width: 140, margin: `10px ${between} 0 ${between}` }}
+          variant="outlined"
+        />
+      ) : null}
     </FormControl>
   );
 };
 
 export const QRCodeGenerator = () => {
   const [input, setInput] = useState('');
-    const sample = faker.internet.url();
+  const sample = faker.internet.url();
 
   const [fileExt, setFileExt] = useState<FileExtension>('png');
   const ref = useRef(null);
 
-    const config = useApi(configApiRef).getOptionalConfig('app.toolbox.qrCode');
+  const config = useApi(configApiRef).getOptionalConfig('app.toolbox.qrCode');
 
-    const defaultColor = '#000';
-    const defaults: QrCodeSettings = {
-        cornerSquareType: config?.getOptionalString('defaults.cornerSquareType') as CornerSquareType ?? 'square',
-        cornerSquareColor: config?.getOptionalString('defaults.cornerSquareColor') ?? defaultColor,
-        cornerDotType: config?.getOptionalString('defaults.cornerDotType') as CornerDotType ?? "square",
-        cornerDotColor: config?.getOptionalString('defaults.cornerDotColor') ?? defaultColor,
-        dotType: config?.getOptionalString('defaults.dotType') as DotType ?? 'square',
-        dotColor: config?.getOptionalString('defaults.dotColor') ?? defaultColor,
-        shape: config?.getOptionalString('defaults.shape') as ShapeType ?? 'square',
-    };
+  const defaultColor = '#000';
+  const defaults: QrCodeSettings = {
+    cornerSquareType:
+      (config?.getOptionalString(
+        'defaults.cornerSquareType',
+      ) as CornerSquareType) ?? 'square',
+    cornerSquareColor:
+      config?.getOptionalString('defaults.cornerSquareColor') ?? defaultColor,
+    cornerDotType:
+      (config?.getOptionalString('defaults.cornerDotType') as CornerDotType) ??
+      'square',
+    cornerDotColor:
+      config?.getOptionalString('defaults.cornerDotColor') ?? defaultColor,
+    dotType:
+      (config?.getOptionalString('defaults.dotType') as DotType) ?? 'square',
+    dotColor: config?.getOptionalString('defaults.dotColor') ?? defaultColor,
+    shape:
+      (config?.getOptionalString('defaults.shape') as ShapeType) ?? 'square',
+  };
 
-    // settings
-    const [settings, setSettings] = React.useState<QrCodeSettings>(defaults);
+  // settings
+  const [settings, setSettings] = React.useState<QrCodeSettings>(defaults);
 
-    const qrCode = useMemo(() => {
-        const qr = new QRCodeStyling({
-            width: 500,
-            height: 500,
+  const qrCode = useMemo(() => {
+    const qr = new QRCodeStyling({
+      width: 500,
+      height: 500,
       image: '',
-            dotsOptions: {
-                color: settings.dotColor,
-                type: settings.dotType,
-            },
-            cornersSquareOptions: {
-                color: settings.cornerSquareColor,
-                type: settings.cornerSquareType,
-            },
-            cornersDotOptions: {
-                color: settings.cornerDotColor,
-                type: settings.cornerDotType,
-            },
-            shape: settings.shape,
-            imageOptions: {
+      dotsOptions: {
+        color: settings.dotColor,
+        type: settings.dotType,
+      },
+      cornersSquareOptions: {
+        color: settings.cornerSquareColor,
+        type: settings.cornerSquareType,
+      },
+      cornersDotOptions: {
+        color: settings.cornerDotColor,
+        type: settings.cornerDotType,
+      },
+      shape: settings.shape,
+      imageOptions: {
         crossOrigin: 'anonymous',
         margin: 20,
-            },
-            margin: 5,
-        });
+      },
+      margin: 5,
+    });
 
-        if (ref.current) {
-            qr.append(ref.current);
-        }
-        return qr;
-  }, [settings.cornerDotColor, settings.cornerDotType, settings.cornerSquareColor, settings.cornerSquareType, settings.dotColor, settings.dotType, settings.shape]);
+    if (ref.current) {
+      qr.append(ref.current);
+    }
+    return qr;
+  }, [
+    settings.cornerDotColor,
+    settings.cornerDotType,
+    settings.cornerSquareColor,
+    settings.cornerSquareType,
+    settings.dotColor,
+    settings.dotType,
+    settings.shape,
+  ]);
 
-    React.useEffect(() => {
-        qrCode.update({
-            data: input,
-            dotsOptions: {
-                color: settings.dotColor,
-                type: settings.dotType,
-            },
-            cornersSquareOptions: {
-                color: settings.cornerSquareColor,
-                type: settings.cornerSquareType,
-            },
-            cornersDotOptions: {
-                color: settings.cornerDotColor,
-                type: settings.cornerDotType,
-            },
-            shape: settings.shape,
-        });
+  React.useEffect(() => {
+    qrCode.update({
+      data: input,
+      dotsOptions: {
+        color: settings.dotColor,
+        type: settings.dotType,
+      },
+      cornersSquareOptions: {
+        color: settings.cornerSquareColor,
+        type: settings.cornerSquareType,
+      },
+      cornersDotOptions: {
+        color: settings.cornerDotColor,
+        type: settings.cornerDotType,
+      },
+      shape: settings.shape,
+    });
   }, [input, qrCode, settings]);
 
-  const onExtensionChange = useCallback((event: SelectChangeEvent) => {
-        setFileExt(event.target.value as FileExtension);
-  }, [setFileExt]);
+  const onExtensionChange = useCallback(
+    (event: SelectChangeEvent) => {
+      setFileExt(event.target.value as FileExtension);
+    },
+    [setFileExt],
+  );
 
   const onDownloadClick = useCallback(() => {
-        void qrCode.download({
+    void qrCode.download({
       extension: fileExt,
-        });
+    });
   }, [fileExt, qrCode]);
 
   const DownloadOptions = (
@@ -184,90 +220,86 @@ export const QRCodeGenerator = () => {
         placeholder="file extension"
         variant="standard"
       >
-        <MenuItem
-          key="png"
-          value="png"
-        >
+        <MenuItem key="png" value="png">
           png
         </MenuItem>
-        <MenuItem
-          key="webp"
-          value="webp"
-        >
+        <MenuItem key="webp" value="webp">
           webp
         </MenuItem>
-        <MenuItem
-          key="jpeg"
-          value="jpeg"
-        >
+        <MenuItem key="jpeg" value="jpeg">
           jpeg
         </MenuItem>
-        <MenuItem
-          key="svg"
-          value="svg"
-        >
+        <MenuItem key="svg" value="svg">
           svg
         </MenuItem>
-    </Select>
-      <Button
-        key="downloadbutton"
-        onClick={onDownloadClick}
-      >
+      </Select>
+      <Button key="downloadbutton" onClick={onDownloadClick}>
         Download
       </Button>
-    </span>);
+    </span>
+  );
 
-    return (
-        <>
-            <Box
-                sx={{margin: 5}} />
+  return (
+    <>
+      <Box sx={{ margin: 5 }} />
 
-            <DefaultEditor
-                additionalTools={[
+      <DefaultEditor
+        additionalTools={[
           <ConfigSelect
             key="dotSelect"
             name="Dot"
             setSettings={setSettings}
             settingKey={'dotType' as const}
-                                  settings={settings}
-            types={['square', 'classy', 'dots', 'classy-rounded', 'extra-rounded', 'rounded'] as DotType[]}
+            settings={settings}
+            types={
+              [
+                'square',
+                'classy',
+                'dots',
+                'classy-rounded',
+                'extra-rounded',
+                'rounded',
+              ] as DotType[]
+            }
           />,
           <ConfigSelect
             key="cornerSquareSelect"
             name="Corner Square"
-                                  setSettings={setSettings}
+            setSettings={setSettings}
             settingKey={'cornerSquareType' as const}
             settings={settings}
-                                  types={['square', 'dot', 'extra-rounded'] as CornerSquareType[]}
+            types={['square', 'dot', 'extra-rounded'] as CornerSquareType[]}
           />,
           <ConfigSelect
             key="cornerDotSelect"
             name="Corner Dot"
             setSettings={setSettings}
             settingKey={'cornerDotType' as const}
-                                  settings={settings}
-                                  types={['dot', 'square'] as CornerDotType[]}
+            settings={settings}
+            types={['dot', 'square'] as CornerDotType[]}
           />,
           <ConfigSelect
             key="shapeSelect"
             name="Shape"
-                                  setSettings={setSettings}
+            setSettings={setSettings}
             settingKey={'shape' as const}
-                                  settings={settings}
+            settings={settings}
             types={['circle', 'square'] as ShapeType[]}
-                    />,
-                ]}
+          />,
+        ]}
         extraRightContent={DownloadOptions}
         input={input}
         inputProps={{ maxLength: 2048 }}
         rightContent={<div ref={ref} />}
         sample={sample}
-        setInput={useCallback((value) => {
-          setInput(value);
-        }, [setInput])}
-            />
-        </>
-    );
+        setInput={useCallback(
+          value => {
+            setInput(value);
+          },
+          [setInput],
+        )}
+      />
+    </>
+  );
 };
 export default QRCodeGenerator;
-

--- a/plugins/toolbox/src/components/Root/tools.tsx
+++ b/plugins/toolbox/src/components/Root/tools.tsx
@@ -185,6 +185,7 @@ export const defaultTools: Tool[] = [
     headerButtons: [
       <Button
         variant="contained"
+        key="entity-validator-button"
         size="small"
         target="_blank"
         href="https://backstage.io/docs/features/software-catalog/descriptor-format"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4757,6 +4757,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     luxon: "npm:^3.4.3"
     monaco-editor: "npm:^0.44.0"
+    qr-code-styling: "npm:^1.6.2"
     quicktype-core: "npm:^23.0.168"
     react-barcode: "npm:^1.4.6"
     react-qr-code: "npm:^2.0.12"
@@ -22700,10 +22701,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"qr-code-styling@npm:^1.6.2":
+  version: 1.8.4
+  resolution: "qr-code-styling@npm:1.8.4"
+  dependencies:
+    qrcode-generator: "npm:^1.4.4"
+  checksum: 10c0/1656833f0ebc7000b4376e1bbe9e1133699b391589f7917eb3b28eeeb32ed45c143f25c4a8a9d2feeb8b0724f1717b41019e012972ac1df022d559f55c6a2947
+  languageName: node
+  linkType: hard
+
 "qr.js@npm:0.0.0":
   version: 0.0.0
   resolution: "qr.js@npm:0.0.0"
   checksum: 10c0/1c6a4c7a58d04e52ec2fee99e39b680fdc5b2a510a981df42c36b716a8eac6634d130fc4d65af8f030f2a07dbf5fa046b97cdfa7456c250ebb50a73916efdcb5
+  languageName: node
+  linkType: hard
+
+"qrcode-generator@npm:^1.4.4":
+  version: 1.4.4
+  resolution: "qrcode-generator@npm:1.4.4"
+  checksum: 10c0/3249fcff98cb9fa17c21329d3dfd895e294a2d6ea48161f7b377010779d41f0cd88668b7fb3478a659725061bb0a770b40a227c2f4853e8c4a6b947a9e8bf17a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Hey :D in our company the internal communications require custom styling of QR codes. Right now they advertise to go to a random website to generate those. I saw an opportunity to support it in the backstage plugin and gave it a go.

I changed which library is used to generate QR codes. This one allows customization, allows the generated image to be saved on rightclick, and allows downloading the image with different formats. 

This does make the code a bit more involved, to allow the user to configure those settings. Also because of the use-case I investigated a way to configure the default styling. I chose to do this via the app-config, but maybe you have a different solution that would be a better fit?