### PR TITLE
feat: set default mode in JwtDecoder.tsx to Decode

### DIFF
--- a/plugins/toolbox/src/components/Encoders/JwtDecoder.tsx
+++ b/plugins/toolbox/src/components/Encoders/JwtDecoder.tsx
@@ -12,7 +12,7 @@ export const JwtDecoder = () => {
   const alertApi = useApi(alertApiRef);
   const [input, setInput] = useState('');
   const [output, setOutput] = useState('');
-  const [mode, setMode] = useState('Encode');
+  const [mode, setMode] = useState('Decode');
   const { t } = useToolboxTranslation();
 
   const exampleJwt =
@@ -150,7 +150,7 @@ ${JSON.stringify(jwtPayload, null, 2)}`);
       mode={mode}
       setInput={setInput}
       setMode={setMode}
-      modes={['Encode', 'Decode']}
+      modes={['Decode', 'Encode']}
       sample={
         mode === 'Encode' ? JSON.stringify(exampleJSON, null, 4) : exampleJwt
       }


### PR DESCRIPTION
The default should be decode, since JWTs are typically consumed much more often than they are created. Most services need to decode and validate incoming tokens on almost every request, while encoding is limited to specific components like authentication servers. This aligns the default behavior with the common workflow, improves developer experience, and emphasizes the security-critical step of token verification.