### PR TITLE
fix(toolboxhomepagecard): tool upload button loads wrong tool

### DIFF
--- a/plugins/toolbox/src/components/Buttons/FileUploadButton.tsx
+++ b/plugins/toolbox/src/components/Buttons/FileUploadButton.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent } from 'react';
+import { ChangeEvent, useId } from 'react';
 import { Button, Tooltip } from '@material-ui/core';
 import AttachFile from '@material-ui/icons/AttachFile';
 import { useToolboxTranslation } from '../../hooks';
@@ -12,9 +12,10 @@ type Props = {
 
 export const FileUploadButton = (props: Props) => {
   const { t } = useToolboxTranslation();
+  const generatedId = useId();
   const {
     onFileLoad,
-    id = 'uploadBtn',
+    id = `uploadBtn-${generatedId}`,
     buttonText = t('components.fileUploadButton.buttonText'),
     accept = '*/*',
   } = props;


### PR DESCRIPTION
This PR adds unique id to upload button so it puts the uploaded file contents in the correct tool

before:
![tool-upload-issue](https://github.com/user-attachments/assets/6c40d0ab-e64d-4ef6-a766-f46ebf9c5c43)

after:
![tool-upload-fix](https://github.com/user-attachments/assets/f8a5e1b6-0edc-43f0-bb55-1da015fb7c89)

fixes #193
