### PR TITLE
fix(toolboxhomepagecard): show "category - name" in homepage cards and tool dropdown

### DIFF
--- a/plugins/toolbox/dev/HomePageWithFactory.tsx
+++ b/plugins/toolbox/dev/HomePageWithFactory.tsx
@@ -1,0 +1,20 @@
+import { CustomHomepageGrid } from '@backstage/plugin-home';
+import {
+  toolboxHomepageCardFactory,
+  useToolboxTranslation,
+} from '@drodil/backstage-plugin-toolbox';
+import { Content, Page } from '@backstage/core-components';
+
+export const HomePageWithFactory = () => {
+  const { t } = useToolboxTranslation();
+  const CustomToolboxHomepageCard = toolboxHomepageCardFactory({ t });
+  return (
+    <Page themeId="home">
+      <Content>
+        <CustomHomepageGrid>
+          <CustomToolboxHomepageCard />
+        </CustomHomepageGrid>
+      </Content>
+    </Page>
+  );
+};

--- a/plugins/toolbox/dev/index.tsx
+++ b/plugins/toolbox/dev/index.tsx
@@ -16,6 +16,7 @@ import { catalogApiRef } from '@backstage/plugin-catalog-react';
 import { rootRouteRef } from '../src/routes';
 import { CatalogApiMock } from './CatalogApiMock';
 import { HomePage } from './HomePage';
+import { HomePageWithFactory } from './HomePageWithFactory';
 
 const extraToolExample = {
   id: 'extra-test',
@@ -73,6 +74,11 @@ createDevApp()
     element: <HomePage />,
     title: 'Home Page',
     path: '/home',
+  })
+  .addPage({
+    element: <HomePageWithFactory />,
+    title: 'Home Page 2',
+    path: '/home2',
   })
   .render();
  */

--- a/plugins/toolbox/package.json
+++ b/plugins/toolbox/package.json
@@ -73,6 +73,7 @@
     "color-convert": "^2.0.1",
     "crypto-hash": "^3.0.0",
     "csvtojson": "^2.0.10",
+    "i18next": "^22.4.15",
     "iban": "^0.0.14",
     "jose": "^5.2.0",
     "js-beautify": "^1.14.9",

--- a/plugins/toolbox/src/components/HomepageCard/ToolboxCardRenderer.tsx
+++ b/plugins/toolbox/src/components/HomepageCard/ToolboxCardRenderer.tsx
@@ -1,0 +1,21 @@
+import { InfoCard } from '@backstage/core-components';
+import { Content } from './Content';
+import { defaultTools } from '../Root';
+import { useToolboxTranslation } from '../../hooks';
+import { getToolTitle } from '../../utils/tools';
+
+export const ToolboxCardRenderer = ({ toolId }: { toolId?: string }) => {
+  const { t } = useToolboxTranslation();
+  const tool = defaultTools.find(tl => tl.id === toolId);
+
+  let title = t('toolsPage.title');
+  if (tool) {
+    title = getToolTitle(tool, t);
+  }
+
+  return (
+    <InfoCard title={title}>
+      <Content toolId={toolId} />
+    </InfoCard>
+  );
+};

--- a/plugins/toolbox/src/components/HomepageCard/index.ts
+++ b/plugins/toolbox/src/components/HomepageCard/index.ts
@@ -1,1 +1,2 @@
 export { Content } from './Content';
+export { ToolboxCardRenderer } from './ToolboxCardRenderer';

--- a/plugins/toolbox/src/components/Root/ToolPage.tsx
+++ b/plugins/toolbox/src/components/Root/ToolPage.tsx
@@ -3,6 +3,7 @@ import { defaultTools } from './tools';
 import { useParams } from 'react-router-dom';
 import { useToolboxTranslation } from '../../hooks';
 import { ToolContainer } from './ToolContainer';
+import { getToolTitle } from '../../utils/tools';
 
 export const ToolPage = (props: ToolsContainerProps) => {
   const { extraTools } = props;
@@ -15,14 +16,7 @@ export const ToolPage = (props: ToolsContainerProps) => {
     return <>{t('toolPage.toolNotAvailable')}</>;
   }
 
-  const title = `${t(
-    `tool.category.${(tool.category ?? 'miscellaneous').toLowerCase()}`,
-    {
-      defaultValue: tool.category ?? 'Miscellaneous',
-    },
-  )} - ${t(`tool.${tool.id}.name`, {
-    defaultValue: tool.displayName ?? tool.name,
-  })}`;
+  const title = getToolTitle(tool, t);
   const description = t(`tool.${tool.id}.description`, {
     defaultValue: tool.description,
   });

--- a/plugins/toolbox/src/components/Root/ToolsContainer.tsx
+++ b/plugins/toolbox/src/components/Root/ToolsContainer.tsx
@@ -2,7 +2,7 @@ import { ReactElement, Suspense, useEffect, useMemo, useState } from 'react';
 import { Content, ContentHeader } from '@backstage/core-components';
 import { useFavoriteStorage } from '../../utils/hooks';
 import SearchIcon from '@material-ui/icons/Search';
-import { defaultTools } from './tools';
+import { getSortedTools } from '../../utils/tools';
 import OpenInNew from '@material-ui/icons/OpenInNew';
 import { FavoriteButton } from '../Buttons';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -160,45 +160,19 @@ export const ToolsContainer = (props: ToolsContainerProps) => {
     }
   }, [value]);
 
+  const favoritesCategory = t('tool.category.favorites');
+  const allTools = getSortedTools({
+    extraTools,
+    tools,
+    favorites,
+    backendTools,
+    toolFilterFunction,
+    favoritesCategory,
+    t,
+  });
+
   const tabs: TabInfo[] = useMemo(() => {
     const tabInfos: TabInfo[] = [];
-    const favoritesCategory = t('tool.category.favorites');
-    const shownTools = tools ?? [...(extraTools ?? []), ...defaultTools];
-    const filteredTools = shownTools
-      .filter(
-        tool =>
-          (tool.requiresBackend === true && backendTools.includes(tool.id)) ||
-          tool.requiresBackend !== true,
-      )
-      .filter(tool => toolFilterFunction?.(tool) ?? true);
-
-    const allTools = filteredTools
-      .map(tool => {
-        if (favorites.includes(tool.id)) {
-          return { ...tool, category: favoritesCategory };
-        }
-        return tool;
-      })
-      .sort((a, b) => {
-        const aCategoryStr = t(
-          `tool.category.${(a.category ?? 'miscellaneous').toLowerCase()}`,
-          {
-            defaultValue: a.category ?? 'Miscellaneous',
-          },
-        );
-        const bCategoryStr = t(
-          `tool.category.${(b.category ?? 'miscellaneous').toLowerCase()}`,
-          {
-            defaultValue: b.category ?? 'Miscellaneous',
-          },
-        );
-        if (aCategoryStr === favoritesCategory) {
-          return -1;
-        } else if (bCategoryStr === favoritesCategory) {
-          return 1;
-        }
-        return (aCategoryStr ?? '').localeCompare(bCategoryStr ?? '');
-      });
 
     tabInfos.push({
       id: '',
@@ -317,15 +291,12 @@ export const ToolsContainer = (props: ToolsContainerProps) => {
       });
     return tabInfos;
   }, [
-    favorites,
+    allTools,
+    favoritesCategory,
     search,
-    extraTools,
-    tools,
     categorySortFunction,
     toolSortFunction,
     welcomePage,
-    backendTools,
-    toolFilterFunction,
     t,
     classes,
   ]);

--- a/plugins/toolbox/src/index.ts
+++ b/plugins/toolbox/src/index.ts
@@ -3,6 +3,7 @@ export {
   ToolboxPage,
   ToolsContainer,
   ToolContainer,
+  toolboxHomepageCardFactory,
   ToolboxHomepageCard,
 } from './plugin';
 export * from '@drodil/backstage-plugin-toolbox-react';

--- a/plugins/toolbox/src/plugin.test.ts
+++ b/plugins/toolbox/src/plugin.test.ts
@@ -1,7 +1,114 @@
-import { toolboxPlugin } from './plugin';
+import { ReactElement, createElement } from 'react';
+import type { TFunction } from 'i18next';
+import {
+  ToolContainer,
+  ToolboxPage,
+  ToolsContainer,
+  toolboxHomepageCardFactory,
+  toolboxPlugin,
+} from './plugin';
 
 describe('toolbox', () => {
   it('should export plugin', () => {
     expect(toolboxPlugin).toBeDefined();
+  });
+
+  it('should export ToolboxPage', () => {
+    expect(ToolboxPage).toBeDefined();
+  });
+
+  it('should export ToolsContainer', () => {
+    expect(ToolsContainer).toBeDefined();
+  });
+
+  it('should export ToolContainer', () => {
+    expect(ToolContainer).toBeDefined();
+  });
+});
+
+describe('toolboxHomepageCardFactory', () => {
+  const mockToolComponent: ReactElement = createElement(
+    'div',
+    null,
+    'Mock Tool',
+  );
+  const mockTool = {
+    id: 'foo',
+    name: 'Foo',
+    category: 'Test',
+    component: mockToolComponent,
+  };
+  const mockTools = [mockTool];
+  const mockT: TFunction = (key: string | string[]) => {
+    const k = Array.isArray(key) ? key[0] : key;
+    return `translated:${k}` as any;
+  };
+
+  it('returns a defined extension', () => {
+    const card = toolboxHomepageCardFactory({
+      name: 'TestCard',
+      title: 'Test',
+      description: 'desc',
+      popupTitle: 'popup',
+      selectorTitle: 'selector',
+      tools: mockTools,
+    });
+    expect(card).toBeDefined();
+  });
+
+  it('uses custom translation function if provided', () => {
+    const card = toolboxHomepageCardFactory({
+      name: 'TestCard',
+      title: 'Test',
+      description: 'desc',
+      popupTitle: 'popup',
+      selectorTitle: 'selector',
+      tools: mockTools,
+      t: mockT,
+    });
+    expect(card).toBeDefined();
+  });
+
+  it('handles options with favorites, extraTools, backendTools, and toolFilterFunction', () => {
+    const mockExtraToolComponent: ReactElement = createElement(
+      'div',
+      null,
+      'Extra Tool',
+    );
+    const extraTool = {
+      id: 'bar',
+      name: 'Bar',
+      category: 'Extra',
+      component: mockExtraToolComponent,
+    };
+    const toolFilterFunction = () => true;
+
+    const card = toolboxHomepageCardFactory({
+      name: 'TestCard',
+      title: 'Test',
+      description: 'desc',
+      popupTitle: 'popup',
+      selectorTitle: 'selector',
+      tools: mockTools,
+      extraTools: [extraTool],
+      favorites: ['foo'],
+      backendTools: ['foo'],
+      toolFilterFunction,
+      favoritesCategory: 'Favorites',
+      t: mockT,
+    });
+    expect(card).toBeDefined();
+  });
+
+  it('uses fallbacks if no translation provided', () => {
+    const card = toolboxHomepageCardFactory({
+      name: 'TestCard',
+      title: 'Test',
+      description: 'desc',
+      popupTitle: 'popup',
+      selectorTitle: 'selector',
+      tools: mockTools,
+    });
+    expect(card).toBeDefined();
   });
 });

--- a/plugins/toolbox/src/plugin.ts
+++ b/plugins/toolbox/src/plugin.ts
@@ -1,3 +1,4 @@
+import type { TFunction } from 'i18next';
 import {
   createApiFactory,
   createPlugin,
@@ -6,11 +7,13 @@ import {
   discoveryApiRef,
   fetchApiRef,
 } from '@backstage/core-plugin-api';
-
 import { rootRouteRef } from './routes';
+import { getSortedTools, getToolTitle } from './utils/tools';
+import { Tool } from '@drodil/backstage-plugin-toolbox-react';
+import { ToolboxCardRenderer } from './components/HomepageCard';
 import { createCardExtension } from '@backstage/plugin-home-react';
-import { defaultTools } from './components/Root';
 import { toolboxApiRef, ToolboxClient } from './api';
+import { defaultTools } from './components/Root';
 
 export const toolboxPlugin = createPlugin({
   id: 'toolbox',
@@ -53,12 +56,105 @@ export const ToolContainer = toolboxPlugin.provide(
   }),
 );
 
+export interface ToolboxHomepageCardOptions {
+  name?: string;
+  title?: string;
+  description?: string;
+  popupTitle?: string;
+  selectorTitle?: string;
+  tools?: Tool[];
+  extraTools?: Tool[];
+  favorites?: string[];
+  backendTools?: string[];
+  toolFilterFunction?: (tool: Tool) => boolean;
+  favoritesCategory?: string;
+  t?: TFunction;
+}
+
+export function toolboxHomepageCardFactory(
+  options: ToolboxHomepageCardOptions = {},
+) {
+  const {
+    name = 'ToolboxHomepageCard',
+    title = 'Toolbox',
+    description = 'Shows tool in the toolbox',
+    popupTitle = 'Toolbox settings',
+    selectorTitle = 'Tools',
+    tools,
+    extraTools,
+    favorites,
+    backendTools,
+    toolFilterFunction,
+    favoritesCategory,
+    t,
+  } = options;
+
+  const sortedTools = getSortedTools({
+    extraTools,
+    tools,
+    favorites,
+    backendTools,
+    toolFilterFunction,
+    favoritesCategory: favoritesCategory ?? 'Favorites',
+    t,
+  });
+  const titleValue = t
+    ? t('toolbox.homepageCard.title', { defaultValue: title })
+    : title;
+  const descriptionValue = t
+    ? t('toolbox.homepageCard.description', { defaultValue: description })
+    : description;
+  const popupTitleValue = t
+    ? t('toolbox.homepageCard.settingsTitle', { defaultValue: popupTitle })
+    : popupTitle;
+  const selectorTitleValue = t
+    ? t('toolbox.homepageCard.selectToolText', { defaultValue: selectorTitle })
+    : selectorTitle;
+  return toolboxPlugin.provide(
+    createCardExtension<{ toolId?: string }>({
+      name,
+      title: titleValue,
+      description: descriptionValue,
+      components: () =>
+        import('./components/HomepageCard').then(m => ({
+          Renderer: ToolboxCardRenderer,
+          Content: m.Content,
+        })),
+      layout: {
+        height: { minRows: 4 },
+        width: { minColumns: 4 },
+      },
+      settings: {
+        schema: {
+          title: popupTitleValue,
+          type: 'object',
+          properties: {
+            toolId: {
+              title: selectorTitleValue,
+              type: 'string',
+              oneOf: sortedTools.map(tool => ({
+                const: tool.id,
+                title: getToolTitle(tool, t),
+              })),
+              default: 'any',
+            },
+          },
+        },
+      },
+    }),
+  );
+}
+
 export const ToolboxHomepageCard = toolboxPlugin.provide(
   createCardExtension<{ toolId?: string }>({
     name: 'ToolboxHomepageCard',
     title: 'Toolbox',
     description: 'Shows wanted tool from the toolbox',
-    components: () => import('./components/HomepageCard'),
+    components: () =>
+      import('./components/HomepageCard').then(m => ({
+        Renderer: ToolboxCardRenderer,
+        Content: m.Content,
+      })),
     layout: {
       height: { minRows: 4 },
       width: { minColumns: 4 },

--- a/plugins/toolbox/src/utils/tools.test.ts
+++ b/plugins/toolbox/src/utils/tools.test.ts
@@ -1,0 +1,175 @@
+import { getSortedTools, getToolTitle } from './tools';
+
+import { TFunction } from 'i18next';
+import { Tool } from '@drodil/backstage-plugin-toolbox-react';
+import { defaultTools } from '../components/Root/tools';
+
+const mockTools: Tool[] = [
+  { id: 'a', name: 'Alpha', category: 'Convert', component: {} as any },
+  { id: 'b', name: 'Beta', category: 'Encode', component: {} as any },
+  { id: 'c', name: 'Gamma', category: 'Convert', component: {} as any },
+];
+
+const mockT: TFunction = (key: string | string[]) => {
+  const k = Array.isArray(key) ? key[0] : key;
+  return `translated:${k}` as any;
+};
+
+describe('getSortedTools', () => {
+  it('returns all tools sorted by category when tools is provided', () => {
+    const result = getSortedTools({
+      tools: mockTools,
+      favoritesCategory: 'Favorites',
+    });
+    expect(result.map(t => t.id)).toEqual(['a', 'c', 'b']);
+  });
+
+  it('places favorites at the beginning and sets their category', () => {
+    const result = getSortedTools({
+      tools: mockTools,
+      favorites: ['b'],
+      favoritesCategory: 'Favorites',
+    });
+    expect(result[0].id).toBe('b');
+    expect(result[0].category).toBe('Favorites');
+  });
+
+  it('filters tools using toolFilterFunction', () => {
+    const result = getSortedTools({
+      tools: mockTools,
+      favoritesCategory: 'Favorites',
+      toolFilterFunction: tool => tool.id !== 'b',
+    });
+    expect(result.map(t => t.id)).toEqual(['a', 'c']);
+  });
+
+  it('uses translation function for category sorting if provided', () => {
+    const result = getSortedTools({
+      tools: mockTools,
+      favoritesCategory: 'Favorites',
+      t: mockT,
+    });
+    expect(result[0].category).toBe('Convert');
+    expect(result[1].category).toBe('Convert');
+    expect(result[2].category).toBe('Encode');
+  });
+
+  it('returns an empty array when tools is empty', () => {
+    const result = getSortedTools({
+      tools: [],
+      favoritesCategory: 'Favorites',
+    });
+    expect(result).toEqual([]);
+  });
+});
+
+describe('getToolTitle', () => {
+  const tool: Tool = {
+    id: 'x',
+    name: 'Xray',
+    category: 'Convert',
+    component: {} as any,
+  };
+
+  it('returns translated title if translation function is provided', () => {
+    const title = getToolTitle(tool, mockT);
+    expect(title).toBe(
+      'translated:tool.category.convert - translated:tool.x.name',
+    );
+  });
+
+  it('returns plain title if translation function is not provided', () => {
+    const title = getToolTitle(tool);
+    expect(title).toBe('Convert - Xray');
+  });
+
+  it('falls back to id and Miscellaneous if name/category are missing', () => {
+    const tool2: Tool = { id: 'y', name: 'tool', component: {} as any };
+    const title = getToolTitle(tool2);
+    expect(title).toBe('Miscellaneous - tool');
+  });
+  it('returns "Name Not Defined" if both displayName and name are missing', () => {
+    const newtool: Tool = {
+      id: '',
+      displayName: 'display name',
+      name: '',
+      component: {} as any,
+    };
+    const title = getToolTitle(newtool);
+    expect(title).toBe('Miscellaneous - display name');
+  });
+
+  it('returns "Name Not Defined" if both displayName and name are empty strings', () => {
+    const newtool: Tool = {
+      id: 'empty',
+      name: '',
+      displayName: '',
+      component: {} as any,
+    };
+    const title = getToolTitle(newtool);
+    expect(title).toBe('Name Not Defined');
+  });
+});
+
+describe('getSortedTools - shownTools and backend filtering', () => {
+  const backendTool: Tool = {
+    id: 'backend',
+    name: 'Backend',
+    category: 'Convert',
+    requiresBackend: true,
+    component: {} as any,
+  };
+  const regularTool: Tool = {
+    id: 'regular',
+    name: 'Regular',
+    category: 'Encode',
+    component: {} as any,
+  };
+
+  it('returns only tools when tools is provided, ignoring extraTools and defaultTools', () => {
+    const result = getSortedTools({
+      tools: [regularTool],
+      extraTools: [backendTool],
+      favoritesCategory: 'Favorites',
+    });
+    expect(result.map(t => t.id)).toEqual(['regular']);
+  });
+
+  it('returns extraTools combined with defaultTools when no tools', () => {
+    const result = getSortedTools({
+      extraTools: [regularTool],
+      favoritesCategory: 'Favorites',
+    });
+    expect(result.some(t => t.id === 'regular')).toBe(true);
+    expect(result.some(t => t.id === defaultTools[0].id)).toBe(true);
+  });
+
+  it('returns only defaultTools when no tools or extraTools', () => {
+    const result = getSortedTools({
+      favoritesCategory: 'Favorites',
+    });
+    const expectedIds = defaultTools
+      .filter(tool => tool.requiresBackend !== true)
+      .map(t => t.id);
+    expect(new Set(result.map(t => t.id))).toEqual(new Set(expectedIds));
+    expect(result).toHaveLength(expectedIds.length);
+  });
+
+  it('excludes tools with requiresBackend=true if not in backendTools', () => {
+    const result = getSortedTools({
+      tools: [backendTool, regularTool],
+      backendTools: [],
+      favoritesCategory: 'Favorites',
+    });
+    expect(result.map(t => t.id)).toEqual(['regular']);
+  });
+
+  it('includes tools with requiresBackend=true if their id is in backendTools', () => {
+    const result = getSortedTools({
+      tools: [backendTool, regularTool],
+      backendTools: ['backend'],
+      favoritesCategory: 'Favorites',
+    });
+    expect(result.map(t => t.id)).toEqual(['backend', 'regular']);
+  });
+});

--- a/plugins/toolbox/src/utils/tools.ts
+++ b/plugins/toolbox/src/utils/tools.ts
@@ -1,0 +1,70 @@
+import { TFunction } from 'i18next';
+import { Tool } from '@drodil/backstage-plugin-toolbox-react';
+import { defaultTools } from '../components/Root/tools';
+
+export interface GetSortedToolsProps {
+  extraTools?: Tool[];
+  tools?: Tool[];
+  favorites?: string[];
+  backendTools?: string[];
+  toolFilterFunction?: (tool: Tool) => boolean;
+  favoritesCategory: string;
+  t?: TFunction;
+}
+
+export function getSortedTools({
+  extraTools,
+  tools,
+  favorites = [],
+  backendTools = [],
+  toolFilterFunction,
+  favoritesCategory,
+  t,
+}: GetSortedToolsProps): Tool[] {
+  const shownTools = tools ?? [...(extraTools ?? []), ...defaultTools];
+  return shownTools
+    .filter(
+      tool =>
+        (tool.requiresBackend === true && backendTools.includes(tool.id)) ||
+        tool.requiresBackend !== true,
+    )
+    .filter(tool => toolFilterFunction?.(tool) ?? true)
+    .map(tool => {
+      if (favorites.includes(tool.id)) {
+        return { ...tool, category: favoritesCategory };
+      }
+      return tool;
+    })
+    .sort((a, b) => {
+      const aCategory = a.category ?? 'Miscellaneous';
+      const bCategory = b.category ?? 'Miscellaneous';
+
+      const aCategoryStr = t
+        ? t(`tool.category.${aCategory.toLowerCase()}`, {
+            defaultValue: aCategory,
+          })
+        : aCategory;
+      const bCategoryStr = t
+        ? t(`tool.category.${bCategory.toLowerCase()}`, {
+            defaultValue: bCategory,
+          })
+        : bCategory;
+
+      if (aCategoryStr === favoritesCategory) return -1;
+      if (bCategoryStr === favoritesCategory) return 1;
+      return aCategoryStr
+        .toLowerCase()
+        .localeCompare(bCategoryStr.toLowerCase());
+    });
+}
+
+export function getToolTitle(tool: Tool, t?: TFunction): string {
+  const name = tool.displayName || tool.name;
+  if (!name) return 'Name Not Defined';
+  const category = tool.category || 'Miscellaneous';
+  if (!t) return `${category} - ${name}`;
+  const categoryKey = `tool.category.${category.toLowerCase()}`;
+  const tName = t(`tool.${tool.id}.name`, { defaultValue: name });
+  const tCategory = t(categoryKey, { defaultValue: category });
+  return `${tCategory} - ${tName}`;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3538,6 +3538,7 @@ __metadata:
     cross-fetch: "npm:^3.1.5"
     crypto-hash: "npm:^3.0.0"
     csvtojson: "npm:^2.0.10"
+    i18next: "npm:^22.4.15"
     iban: "npm:^0.0.14"
     jose: "npm:^5.2.0"
     js-beautify: "npm:^1.14.9"


### PR DESCRIPTION
This PR preserves Homepage and dropdown implementations for backwards compatibility and introduces a new HomepageWithFactory component in the dev server to demonstrate the updated "category - name" display. It updates ToolboxHomepageCard to show "category - name" instead of "Toolbox" and extracts shared logic for tool list sorting and title display into a utility file.

dropdown using factory:
<img width="1664" height="900" alt="dropdown-with-factory" src="https://github.com/user-attachments/assets/fbfd6180-a20a-4b18-b000-8b465371213c" />

tool cards before:
<img width="1558" height="966" alt="cards-before" src="https://github.com/user-attachments/assets/3702c927-ca20-4288-b94d-f036bdfd603d" />

home cards after:
<img width="1664" height="1069" alt="home-cards" src="https://github.com/user-attachments/assets/69a80f30-2172-45b2-b5b5-416a9bd4d863" />

home2 cards:
<img width="1664" height="1063" alt="home2-cards" src="https://github.com/user-attachments/assets/cf4d4cbc-a9a5-4033-a605-83d5181a4d19" />

fix #186 