### PR TITLE
feat(hash): update UI to show hash results in a single page

### DIFF
--- a/plugins/toolbox/src/components/DefaultEditor/OutputField.tsx
+++ b/plugins/toolbox/src/components/DefaultEditor/OutputField.tsx
@@ -5,16 +5,20 @@ import styles from './DefaultEditor.module.css';
 export const OutputField = (props: {
   label: string;
   value?: string | null;
+  rows?: number;
+  flexDirection?: 'row' | 'column';
+  textAreaStyle?: React.CSSProperties;
 }) => {
-  const { label, value } = props;
+  const { label, value, flexDirection, rows, textAreaStyle } = props;
   return (
-    <Flex direction="column" gap="2">
+    <Flex direction={flexDirection ?? 'column'} gap="2">
       <label className={styles.fieldLabel}>{label}</label>
       <textarea
         className={styles.textarea}
         readOnly
         value={value ?? ''}
-        rows={5}
+        rows={rows ?? 5}
+        style={textAreaStyle ?? {}}
       />
       <CopyToClipboardButton output={value ?? ''} />
     </Flex>

--- a/plugins/toolbox/src/components/Generators/Hash.tsx
+++ b/plugins/toolbox/src/components/Generators/Hash.tsx
@@ -8,6 +8,7 @@ import md2 from 'js-md2';
 // @ts-ignore
 import md4 from 'js-md4';
 import { OutputField } from '../DefaultEditor/OutputField';
+import { Flex } from '@backstage/ui';
 
 export const Hash = () => {
   const [input, setInput] = useState('');
@@ -43,6 +44,10 @@ export const Hash = () => {
       });
     });
   }, [input]);
+  const textAreaStyle: React.CSSProperties = {
+    minHeight: '1lh',
+    fieldSizing: 'content',
+  } as React.CSSProperties;
 
   return (
     <DefaultEditor
@@ -51,15 +56,57 @@ export const Hash = () => {
       sample={sample}
       allowFileUpload
       rightContent={
-        <>
-          <OutputField label="MD2" value={hash.md2} />
-          <OutputField label="MD4" value={hash.md4} />
-          <OutputField label="MD5" value={hash.md5} />
-          <OutputField label="SHA1" value={hash.sha1} />
-          <OutputField label="SHA256" value={hash.sha256} />
-          <OutputField label="SHA384" value={hash.sha384} />
-          <OutputField label="SHA512" value={hash.sha512} />
-        </>
+        <Flex direction="column" gap="2">
+          <OutputField
+            label="MD2"
+            value={hash.md2}
+            rows={1}
+            flexDirection="row"
+            textAreaStyle={textAreaStyle}
+          />
+          <OutputField
+            label="MD4"
+            value={hash.md4}
+            rows={1}
+            flexDirection="row"
+            textAreaStyle={textAreaStyle}
+          />
+          <OutputField
+            label="MD5"
+            value={hash.md5}
+            rows={1}
+            flexDirection="row"
+            textAreaStyle={textAreaStyle}
+          />
+          <OutputField
+            label="SHA1"
+            value={hash.sha1}
+            rows={1}
+            flexDirection="row"
+            textAreaStyle={textAreaStyle}
+          />
+          <OutputField
+            label="SHA256"
+            value={hash.sha256}
+            rows={1}
+            flexDirection="row"
+            textAreaStyle={textAreaStyle}
+          />
+          <OutputField
+            label="SHA384"
+            value={hash.sha384}
+            rows={1}
+            flexDirection="row"
+            textAreaStyle={textAreaStyle}
+          />
+          <OutputField
+            label="SHA512"
+            value={hash.sha512}
+            rows={1}
+            flexDirection="row"
+            textAreaStyle={textAreaStyle}
+          />
+        </Flex>
       }
     />
   );


### PR DESCRIPTION
The hash tool used to have very large output text areas. This commit fixes that by adding a few properties to `OutputField`, allowing custom styling, flex direction and setting the number of rows displayed.

The result is a cleaner looking page for hash display, with all of the computed hashes in a single page, without having to scroll.

The style makes use of the new "field-sizing" CSS property, which is not available on older browsers, but the only downside is having the text area crop the result a little, which is not too big of an issue and probably not worth the tradeoff of adding retro-compatibility for.

The copy to clipboard button is also moved to the side to make the UI more compact.