### PR TITLE
feat(config): add config 'enabled' to enable a selection of tools

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -56,4 +56,3 @@ backend:
   reading:
     allow:
       - host: localhost
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -114,6 +114,44 @@ backend.add(import('@drodil/backstage-plugin-toolbox-backend-module-whois'));
 backend.start();
 ```
 
+# Configuration
+
+## Disabling specific tools
+
+Disabling a tool is done easily through `app.extensions` overrides in `app-config.yaml`.
+To completely disable a tool, simply target said tool, and set the disabled attribute
+to false:
+
+```yaml
+app:
+  extensions:
+    - toolbox-tool:toolbox/base64-encode:
+        disabled: true
+```
+
+Or as a shorthand:
+
+```yaml
+app:
+  extensions:
+    - toolbox-tool:toolbox/base64-encode: false
+```
+
+If you would rather just exclude the tool from the toolbox page, you can instead
+override the `page:toolbox` extension and set the `enabledTools` config key to an
+array of the tool IDs you want to keep on the toolbox page:
+
+```yaml
+app:
+  extensions:
+    - page:toolbox:
+        config:
+          enabledTools:
+            - sla-calculator
+            - csr-generate
+            - ...
+```
+
 # Translations
 
 The plugin supports i18n. To add a new language, create a locale file in your app:

--- a/plugins/toolbox/package.json
+++ b/plugins/toolbox/package.json
@@ -90,7 +90,8 @@
     "turndown": "^7.1.2",
     "turndown-plugin-gfm": "^1.0.2",
     "xml-js": "^1.6.11",
-    "yaml": "^2.8.3"
+    "yaml": "^2.8.3",
+    "zod": "^4.4.3"
   },
   "peerDependencies": {
     "@backstage/catalog-client": "^1.16.1",

--- a/plugins/toolbox/src/plugin.tsx
+++ b/plugins/toolbox/src/plugin.tsx
@@ -19,6 +19,7 @@ import {
 } from '@drodil/backstage-plugin-toolbox-react';
 // Imported early so the settings schema enum can reference built-in tool IDs
 import { defaultTools } from './components/Root';
+import { z } from 'zod/v4';
 
 export {
   toolDataRef,
@@ -59,10 +60,17 @@ const toolboxPage = PageBlueprint.makeWithOverrides({
       optional: true,
     }),
   },
+  configSchema: {
+    enabledTools: z.array(z.string()).optional(),
+  },
   factory: (originalFactory, { config, inputs }) => {
-    const tools = inputs.tools.map(t =>
-      t.get(ToolboxToolBlueprint.dataRefs.tool),
-    );
+    const tools = inputs.tools
+      .map(t => t.get(ToolboxToolBlueprint.dataRefs.tool))
+      .filter(
+        t =>
+          config.enabledTools === undefined ||
+          config.enabledTools.includes(t.id),
+      );
     const welcomePage = inputs.welcomePage?.get(coreExtensionData.reactElement);
     return originalFactory({
       path: config.path ?? '/toolbox',
@@ -604,6 +612,44 @@ const homeCard = HomePageWidgetBlueprint.make({
   },
 });
 
+const toolExtensions = [
+  base64EncodeTool,
+  urlEncodeTool,
+  htmlEntitiesEncodeTool,
+  backslashEncodeTool,
+  jwtDecoderTool,
+  markdownPreviewTool,
+  csvToJsonTool,
+  jsonConverterTool,
+  xmlToJsonTool,
+  yamlToJsonTool,
+  richTextToMarkdownTool,
+  numberBaseTool,
+  stringUtilitiesTool,
+  timeConverterTool,
+  colorConverterTool,
+  slaCalculatorTool,
+  hashTool,
+  entityValidatorTool,
+  csrTool,
+  qrCodeTool,
+  barCodeTool,
+  loremIpsumTool,
+  interfaceTool,
+  jsBeautifyTool,
+  htmlBeautifyTool,
+  cssBeautifyTool,
+  sqlBeautifyTool,
+  stringAnalyzerTool,
+  countdownTool,
+  stopwatchTool,
+  diffTool,
+  urlExploderTool,
+  ibanValidatorTool,
+  regexValidatorTool,
+  whoisTool,
+];
+
 const toolboxPlugin: OverridableFrontendPlugin = createFrontendPlugin({
   pluginId: 'toolbox',
   info: { packageJson: () => import('../package.json') },
@@ -614,41 +660,7 @@ const toolboxPlugin: OverridableFrontendPlugin = createFrontendPlugin({
     toolboxApi,
     toolboxPage,
     // Tools
-    base64EncodeTool,
-    urlEncodeTool,
-    htmlEntitiesEncodeTool,
-    backslashEncodeTool,
-    jwtDecoderTool,
-    markdownPreviewTool,
-    csvToJsonTool,
-    jsonConverterTool,
-    xmlToJsonTool,
-    yamlToJsonTool,
-    richTextToMarkdownTool,
-    numberBaseTool,
-    stringUtilitiesTool,
-    timeConverterTool,
-    colorConverterTool,
-    slaCalculatorTool,
-    hashTool,
-    entityValidatorTool,
-    csrTool,
-    qrCodeTool,
-    barCodeTool,
-    loremIpsumTool,
-    interfaceTool,
-    jsBeautifyTool,
-    htmlBeautifyTool,
-    cssBeautifyTool,
-    sqlBeautifyTool,
-    stringAnalyzerTool,
-    countdownTool,
-    stopwatchTool,
-    diffTool,
-    urlExploderTool,
-    ibanValidatorTool,
-    regexValidatorTool,
-    whoisTool,
+    ...toolExtensions,
     homeCard,
   ],
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4315,6 +4315,7 @@ __metadata:
     turndown-plugin-gfm: "npm:^1.0.2"
     xml-js: "npm:^1.6.11"
     yaml: "npm:^2.8.3"
+    zod: "npm:^4.4.3"
   peerDependencies:
     "@backstage/catalog-client": ^1.16.1
     "@backstage/catalog-model": ^1.9.0
@@ -28252,7 +28253,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.25.76 || ^4.0.0, zod@npm:^4.0.0, zod@npm:^4.3.6":
+"zod@npm:^3.25.76 || ^4.0.0, zod@npm:^4.0.0, zod@npm:^4.3.6, zod@npm:^4.4.3":
   version: 4.4.3
   resolution: "zod@npm:4.4.3"
   checksum: 10c0/7ea31b558e88f9faf44f31dd185e2e1cbf51fed3081787fb96cc2534749b50c0acfc6da7f0922a7353ed092dd358c7d50c28ea96c94d04af64191bd33152eca3


### PR DESCRIPTION
This adds an "enabledTools" key in the frontend configuration that enables
a subset of the tools provided in this (and third-party) package.

This features allows people to control which tools are displayed, in
order to have a toolbox that actually fits their needs.

I added the "enabledTools" configuration as an `Array<string>` because it was
the simplest implementation I could think of. Disabling specific tools
is already handled by backstage core, so there is no need to duplicate
the feature.